### PR TITLE
fixed python3 longtype TypeError

### DIFF
--- a/twitter_tap/tap.py
+++ b/twitter_tap/tap.py
@@ -12,7 +12,7 @@ if six.PY2:
     longtype = six.integer_types[1]
 if six.PY3:
     import urllib.parse as urlparse
-    longtype = six.integer_types
+    longtype = six.integer_types[0]
 from datetime import datetime
 from email.utils import parsedate
 


### PR DESCRIPTION
This fixes TypeError with longtype on python 3.x like below.

    $ tap search --consumer-key CONSUMERKEY --consumer-secret CONSUMERSECRET -q "miley cyrus" -v DEBUG
    ...
    [2016-04-29 01:28:29,877] DEBUG: Rate limit for current window: 449
    Traceback (most recent call last):
      File "/home/vagrant/.pyenv/versions/miniconda3-3.16.0/bin/tap", line 11, in <module>
        sys.exit(main())
      File "/home/vagrant/.pyenv/versions/miniconda3-3.16.0/lib/python3.4/site-packages/twitter_tap/tap.py", line 209, in main
        current_since_id = longtype(since_id)
    TypeError: 'tuple' object is not callable
    $